### PR TITLE
use tinyfk solver in trajectory optimization  

### DIFF
--- a/examples/collision_free_trajectory.py
+++ b/examples/collision_free_trajectory.py
@@ -6,12 +6,10 @@ import time
 from skrobot.utils import sdf_box
 
 if __name__ == '__main__':
+    debug = True
     robot_model = skrobot.models.urdf.RobotModelFromURDF(
         urdf_file=skrobot.data.pr2_urdfpath())
     robot_model.init_pose()
-    viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
-    viewer.add(robot_model)
-    viewer.show()
 
     link_idx_table = {}
     for link_idx in range(len(robot_model.link_list)):
@@ -47,7 +45,12 @@ if __name__ == '__main__':
         extents=box_width, face_colors=(1., 0, 0)
     )
     box.translate(box_center)
-    viewer.add(box)
+
+    if debug:
+        viewer = skrobot.viewers.TrimeshSceneViewer(resolution=(640, 480))
+        viewer.add(robot_model)
+        viewer.show()
+        viewer.add(box)
     margin = 0.1
 
     def sdf(X):
@@ -57,9 +60,10 @@ if __name__ == '__main__':
         target_coords, 10, link_list, rarm_end_coords,
         [rarm_end_coords, forarm_coords], sdf)
 
-    time.sleep(1.0)
-    print("show trajectory")
-    for av in traj:
-        set_joint_angles(av)
-        viewer.redraw()
+    if debug:
         time.sleep(1.0)
+        print("show trajectory")
+        for av in traj:
+            set_joint_angles(av)
+            viewer.redraw()
+            time.sleep(1.0)

--- a/skrobot/models/urdf.py
+++ b/skrobot/models/urdf.py
@@ -1,5 +1,5 @@
 from ..model import RobotModel
-
+import pyrobotfk
 
 class RobotModelFromURDF(RobotModel):
 
@@ -16,6 +16,7 @@ class RobotModelFromURDF(RobotModel):
             self.load_urdf_file(file_obj=urdf_file)
         else:
             self.load_urdf_file(file_obj=self.default_urdf_path)
+        self.fksolver = pyrobotfk.RoboticTree(self.urdf_path)
 
     @property
     def default_urdf_path(self):

--- a/skrobot/models/urdf.py
+++ b/skrobot/models/urdf.py
@@ -1,5 +1,5 @@
 from ..model import RobotModel
-import pyrobotfk
+import tinyfk
 
 class RobotModelFromURDF(RobotModel):
 
@@ -16,7 +16,7 @@ class RobotModelFromURDF(RobotModel):
             self.load_urdf_file(file_obj=urdf_file)
         else:
             self.load_urdf_file(file_obj=self.default_urdf_path)
-        self.fksolver = pyrobotfk.RoboticTree(self.urdf_path)
+        self.fksolver = tinyfk.RobotModel(self.urdf_path)
 
     @property
     def default_urdf_path(self):

--- a/skrobot/planner.py
+++ b/skrobot/planner.py
@@ -174,9 +174,11 @@ def plan_trajectory(self,
             [av_init + i * regular_interval for i in range(n_wp)])
 
     if use_cpp:
+        """
         raise Exception("you must set the initial WHOLE angle vector beforehand. \
                 e.g. even if you do not use torso in planning, you must set it . \ 
                 to reflect the skrobot's joint angles to the tinyfk")
+        """
 
 
         fksolver = self.fksolver 
@@ -184,7 +186,7 @@ def plan_trajectory(self,
         fks_collisionlink_ids = util_fksolver_get_linkids(fksolver, coll_cascaded_coords_list)
         def collision_fk(av_seq):
             rot_also = False
-            J, P = self.fksolver.compute_trajectory_jacobians(
+            P, J = self.fksolver.solve_forward_kinematics(
                     av_seq, 
                     fks_collisionlink_ids,
                     fks_joint_ids,
@@ -210,7 +212,10 @@ def plan_trajectory(self,
                                  signed_distance_function,
                                  weights=weights,
                                  )
+    import time
+    ts = time.time()
     optimal_trajectory = opt.solve()
+    print("solving time is {0} sec".format(time.time() -ts))
     return optimal_trajectory
 
 def construct_smoothcost_fullmat(n_dof, n_wp, weights=None):

--- a/skrobot/planner.py
+++ b/skrobot/planner.py
@@ -174,6 +174,11 @@ def plan_trajectory(self,
             [av_init + i * regular_interval for i in range(n_wp)])
 
     if use_cpp:
+        raise Exception("you must set the initial WHOLE angle vector beforehand. \
+                e.g. even if you do not use torso in planning, you must set it . \ 
+                to reflect the skrobot's joint angles to the tinyfk")
+
+
         fksolver = self.fksolver 
         fks_joint_ids = util_fksolver_get_jointids(fksolver, joint_list)
         fks_collisionlink_ids = util_fksolver_get_linkids(fksolver, coll_cascaded_coords_list)


### PR DESCRIPTION
The jacobian computation by [tinyfk](https://github.com/HiroIshida/tinyfk) is over 100x faster than the that of scikit-robot. 10 waypoints trajectory optimization is solved in 4.26 sec with native jacobian computation but in 0.035 sec with tinyfk.  Switching between, native (skrobot) and tinyfk's forward kinematics computaion can be easily be done by setting `use_cpp=True` or `False`. 