### PR TITLE
Improved transformation computation time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install APT On Linux
       run: |
         sudo apt-get update -qq -y
-        sudo apt-get install -qq -y libspatialindex-dev freeglut3-dev
+        sudo apt-get install -qq -y libspatialindex-dev freeglut3-dev libtinyxml-dev
     - name: Install Pytest
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/examples/collision_free_trajectory.py
+++ b/examples/collision_free_trajectory.py
@@ -6,8 +6,8 @@ import numpy as np
 import skrobot
 from skrobot.model.primitives import Axis
 from skrobot.model.primitives import Box
-from skrobot.planner import sqp_plan_trajectory
-from skrobot.planner import SweptSphereSdfCollisionChecker
+from skrobot.planner import tinyfk_sqp_plan_trajectory
+from skrobot.planner import TinyfkSweptSphereSdfCollisionChecker
 from skrobot.planner.utils import get_robot_config
 from skrobot.planner.utils import set_robot_config
 
@@ -53,13 +53,13 @@ robot_model.inverse_kinematics(
 av_goal = get_robot_config(robot_model, joint_list, with_base=with_base)
 
 # collision checker setup
-sscc = SweptSphereSdfCollisionChecker(lambda X: box.sdf(X), robot_model)
+sscc = TinyfkSweptSphereSdfCollisionChecker(lambda X: box.sdf(X), robot_model)
 for link in coll_link_list:
     sscc.add_collision_link(link)
 
 # motion planning
 ts = time.time()
-av_seq = sqp_plan_trajectory(
+av_seq = tinyfk_sqp_plan_trajectory(
     sscc, av_start, av_goal, joint_list, 10,
     safety_margin=1e-2, with_base=with_base)
 print("solving time : {0} sec".format(time.time() - ts))

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ trimesh>=3.5.20
 sphinx==1.8.2
 sphinx_rtd_theme
 repoze.lru;python_version<"3.2"
+tinyfk>=0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ trimesh>=3.5.20
 sphinx==1.8.2
 sphinx_rtd_theme
 repoze.lru;python_version<"3.2"
-tinyfk>=0.2.3
+tinyfk>=0.3.0

--- a/skrobot/coordinates/__init__.py
+++ b/skrobot/coordinates/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import CascadedCoords
 from .base import Coordinates
+from .base import Transform
 from .base import make_coords
 from .base import make_cascoords
 

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -78,23 +78,70 @@ def transform_coords(c1, c2, out=None):
 
 
 class Transform(object):
+    """Transform specified by translation and rotation
+
+    Parameters
+    ----------
+    translation : list(3,) or numpy.ndarray(3,)
+        translation
+    rot : numpy.ndarray(3, 3)
+        3x3 rotation matrix
+    """
+
     def __init__(self, translation, rotation):
         self.translation = np.array(translation)
         self.rotation = rotation
 
     def __call__(self, pts):
-        return pts.dot(self.rotation) + self.translation[None, :]
+        """Apply this transform to point/points
+
+        Parameters
+        ----------
+        pts : numpy.ndarray(3,) or numpy.ndarray(n_points, 3)
+            point/points to be transformed
+
+        Returns
+        -------
+        pts_transformed : numpy.ndarray(3,) or numpy.ndarray(n_points, 3)
+            transformed points
+        """
+        assert pts.ndim < 3, "pts must be either 1 or 2 dimensional."
+        if pts.ndim == 1:
+            return pts.dot(self.rotation) + self.translation
+        if pts.ndim == 2:
+            return pts.dot(self.rotation) + self.translation[None, :]
 
     def get_inverse(self):
+        """Return inverse transform
+
+        Returns
+        -------
+        inv_transform : skrobot.coordinates.base.Transform
+            inverse transformation
+        """
         return Transform(-self.translation, self.rotation.T)
 
     def __mull__(self, tf_23):
+        """Composite this transform with other transform
+
+        Parameters
+        ----------
+        tf_23 : skrobot.coordinates.base.Transform
+            the other transform.
+
+        Returns
+        -------
+        tf_13 : skrobot.coordinates.base.Transform
+            Let this (self) transform as tf_12, then with the
+            other transform tf_23, we obtain tf_13 = tf_12 * tf_23
+        """
         tf_12 = self
         tran_12, rot_12 = tf_12.translation, tf_12.rotation
         tran_23, rot_23 = tf_23.translation, tf_23.rotation
         rot_13 = rot_12.dot(rot_23)
         tran_13 = tran_23 + rot_23.dot(tran_12)
-        return Transform(tran_13, rot_13)
+        tf_13 = Transform(tran_13, rot_13)
+        return tf_13
 
 
 class Coordinates(object):
@@ -134,9 +181,6 @@ class Coordinates(object):
         self.parent = None
         self._hook = hook if hook else lambda: None
 
-    def get_transform(self):
-        return Transform(self.worldpos(), self.worldrot())
-
     @contextlib.contextmanager
     def disable_hook(self):
         hook = self._hook
@@ -145,6 +189,16 @@ class Coordinates(object):
             yield
         finally:
             self._hook = hook
+
+    def get_transform(self):
+        """Return Transform object
+
+        Returns
+        -------
+        transform : skrobot.coordinates.base.Transform
+            corrensponding Transform to this coordinates
+        """
+        return Transform(self.worldpos(), self.worldrot())
 
     @property
     def rotation(self):

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -107,9 +107,9 @@ class Transform(object):
         """
         assert pts.ndim < 3, "pts must be either 1 or 2 dimensional."
         if pts.ndim == 1:
-            return pts.dot(self.rotation) + self.translation
+            return self.rotation.dot(pts.T) + self.translation
         if pts.ndim == 2:
-            return pts.dot(self.rotation) + self.translation[None, :]
+            return self.rotation.dot(pts.T).T + self.translation[None, :]
 
     def get_inverse(self):
         """Return inverse transform
@@ -119,9 +119,11 @@ class Transform(object):
         inv_transform : skrobot.coordinates.base.Transform
             inverse transformation
         """
-        return Transform(-self.translation, self.rotation.T)
+        new_rot = self.rotation.T
+        new_trans = -new_rot.dot(self.translation)
+        return Transform(new_trans, new_rot)
 
-    def __mull__(self, tf_23):
+    def __mul__(self, tf_23):
         """Composite this transform with other transform
 
         Parameters
@@ -138,10 +140,13 @@ class Transform(object):
         tf_12 = self
         tran_12, rot_12 = tf_12.translation, tf_12.rotation
         tran_23, rot_23 = tf_23.translation, tf_23.rotation
-        rot_13 = rot_12.dot(rot_23)
+        rot_13 = rot_23.dot(rot_12)
         tran_13 = tran_23 + rot_23.dot(tran_12)
         tf_13 = Transform(tran_13, rot_13)
         return tf_13
+
+    def __rmul__(self, other):
+        return other.__mul__(self)
 
 
 class Coordinates(object):

--- a/skrobot/coordinates/base.py
+++ b/skrobot/coordinates/base.py
@@ -77,6 +77,26 @@ def transform_coords(c1, c2, out=None):
     return out
 
 
+class Transform(object):
+    def __init__(self, translation, rotation):
+        self.translation = np.array(translation)
+        self.rotation = rotation
+
+    def __call__(self, pts):
+        return pts.dot(self.rotation) + self.translation[None, :]
+
+    def get_inverse(self):
+        return Transform(-self.translation, self.rotation.T)
+
+    def __mull__(self, tf_23):
+        tf_12 = self
+        tran_12, rot_12 = tf_12.translation, tf_12.rotation
+        tran_23, rot_23 = tf_23.translation, tf_23.rotation
+        rot_13 = rot_12.dot(rot_23)
+        tran_13 = tran_23 + rot_23.dot(tran_12)
+        return Transform(tran_13, rot_13)
+
+
 class Coordinates(object):
 
     """Coordinates class to manipulate rotation and translation.
@@ -113,6 +133,9 @@ class Coordinates(object):
         self.name = name
         self.parent = None
         self._hook = hook if hook else lambda: None
+
+    def get_transform(self):
+        return Transform(self.worldpos(), self.worldrot())
 
     @contextlib.contextmanager
     def disable_hook(self):

--- a/skrobot/planner/__init__.py
+++ b/skrobot/planner/__init__.py
@@ -2,3 +2,6 @@
 
 from skrobot.planner.collision_checker import SweptSphereSdfCollisionChecker
 from skrobot.planner.sqp_based import sqp_plan_trajectory
+
+from skrobot.planner.tinyfk_collision_checker import TinyfkSweptSphereSdfCollisionChecker
+from skrobot.planner.tinyfk_sqp_based import tinyfk_sqp_plan_trajectory

--- a/skrobot/planner/collision_checker.py
+++ b/skrobot/planner/collision_checker.py
@@ -82,6 +82,7 @@ class SweptSphereSdfCollisionChecker(object):
         self.coll_coords_list.extend(coords_list)
         self.coll_radius_list.extend([R] * len(sphere_list))
         self.n_feature = len(self.coll_coords_list)
+        return centers, coords_list, sphere_list, R
 
     def update_color(self):  # for debugging
         """Update the color of links under collision

--- a/skrobot/planner/tinyfk_collision_checker.py
+++ b/skrobot/planner/tinyfk_collision_checker.py
@@ -1,0 +1,73 @@
+import tinyfk
+
+from skrobot.planner import SweptSphereSdfCollisionChecker
+
+
+class TinyfkSweptSphereSdfCollisionChecker(SweptSphereSdfCollisionChecker):
+    """Collision checker using tinyfk as a backend"""
+
+    def __init__(self, sdf, robot_model):
+        super(TinyfkSweptSphereSdfCollisionChecker, self).__init__(
+            sdf, robot_model)
+        self.fksolver = tinyfk.RobotModel(robot_model.urdf_path)
+        self.coll_sphere_id_list = []
+
+    def add_collision_link(self, coll_link):
+        center_list, _, sphere_list, _ =\
+            super(TinyfkSweptSphereSdfCollisionChecker, self).\
+            add_collision_link(coll_link)
+        coll_link_id = self.fksolver.get_link_ids([coll_link.name])[0]
+        sphere_name_list = [s.name for s in sphere_list]
+        for name, center in zip(sphere_name_list, center_list):
+            self.fksolver.add_new_link(name, coll_link_id, center)
+
+        sphere_ids = self.fksolver.get_link_ids(sphere_name_list)
+        self.coll_sphere_id_list.extend(sphere_ids)
+
+    def compute_batch_sd_vals(
+            self,
+            joint_list,
+            angle_vector_seq,
+            with_base=False,
+            with_jacobian=False):
+        """Mocking compute_batch_sd_vals of the super class
+
+        get_joint_ids comes with some overhead, which is critical
+        in the cpp based trajectory planner. So, Do not call this,
+        and instead, call _compute_batchsd_vals in path-planning
+        applications.
+        """
+        joint_name_list = [j.name for j in joint_list]
+        joint_ids = self.fksolver.get_joint_ids(joint_name_list)
+        return self._compute_batch_sd_vals(
+            joint_ids,
+            angle_vector_seq,
+            with_base=with_base,
+            with_jacobian=with_jacobian)
+
+    def _compute_batch_sd_vals(
+            self,
+            joint_ids,
+            angle_vector_seq,
+            with_base=False,
+            with_jacobian=False):
+        """This will be called from the optimization
+
+        As python doesn't supprot multiple dispatch,
+        we define _compute_batchsd_vals whcih takes
+        different type of arguments.
+        """
+
+        n_wp, n_dof = angle_vector_seq.shape
+        with_rot = False
+        P_tmp, J_tmp = self.fksolver.solve_forward_kinematics(
+            angle_vector_seq, self.coll_sphere_id_list, joint_ids,
+            with_rot, with_base, with_jacobian)
+        # because pybind can handle only 2-dim matrix, we must reshape it
+        P = P_tmp.reshape(n_wp, self.n_feature, 3)
+        if with_jacobian:
+            J = J_tmp.reshape(n_wp, self.n_feature, 3, n_dof)
+        else:
+            J = None
+        sd_vals, sd_vals_jacobi = self._compute_batch_sd_vals_internal(P, J)
+        return sd_vals, sd_vals_jacobi

--- a/skrobot/planner/tinyfk_sqp_based.py
+++ b/skrobot/planner/tinyfk_sqp_based.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from skrobot.planner.sqp_based import _sqp_based_trajectory_optimization
+
+
+def tinyfk_sqp_plan_trajectory(collision_checker,
+                               av_start,
+                               av_goal,
+                               joint_list,
+                               n_wp,
+                               safety_margin=1e-2,
+                               with_base=False,
+                               weights=None,
+                               initial_trajectory=None,
+                               slsqp_option=None
+                               ):
+    # common stuff
+    joint_limit_list = [[j.min_angle, j.max_angle] for j in joint_list]
+    if with_base:
+        joint_limit_list += [[-np.inf, np.inf]] * 3
+
+    # determine default weight
+    if weights is None:
+        weights = [1.0] * len(joint_list)
+        if with_base:
+            weights += [3.0] * 3  # base should be difficult to move
+    weights = tuple(weights)  # to use cache
+
+    # create initial solution for the optimization problem
+    if initial_trajectory is None:
+        regular_interval = (av_goal - av_start) / (n_wp - 1)
+        initial_trajectory = np.array(
+            [av_start + i * regular_interval for i in range(n_wp)])
+
+    joint_name_list = [j.name for j in joint_list]
+    joint_ids = collision_checker.fksolver.get_joint_ids(joint_name_list)
+
+    def collision_ineq_fun(av_seq):
+        with_jacobian = True
+        sd_vals, sd_val_jac = collision_checker._compute_batch_sd_vals(
+            joint_ids, av_seq,
+            with_base=with_base, with_jacobian=with_jacobian)
+        sd_vals_margined = sd_vals - safety_margin
+        return sd_vals_margined, sd_val_jac
+
+    optimal_trajectory = _sqp_based_trajectory_optimization(
+        initial_trajectory,
+        collision_ineq_fun,
+        joint_limit_list,
+        weights,
+        slsqp_option)
+    return optimal_trajectory

--- a/skrobot/sdf/signed_distance_function.py
+++ b/skrobot/sdf/signed_distance_function.py
@@ -110,7 +110,7 @@ class SignedDistanceFunction(object):
         """
         tf_world_to_local = self.coords.get_transform().get_inverse()
         tf_local_to_sdf = self.sdf_to_obj_transform.get_inverse()
-        tf_world_to_sdf = tf_world_to_local.__mull__(tf_local_to_sdf)
+        tf_world_to_sdf = tf_world_to_local * tf_local_to_sdf
         points_sdf = tf_world_to_sdf(points_obj)
         return points_sdf
 
@@ -129,7 +129,7 @@ class SignedDistanceFunction(object):
         """
         tf_local_to_world = self.coords.get_transform()
         tf_sdf_to_local = self.sdf_to_obj_transform
-        tf_sdf_to_world = tf_sdf_to_local.__mull__(tf_local_to_world)
+        tf_sdf_to_world = tf_sdf_to_local * tf_local_to_world
         points_obj = tf_sdf_to_world(points_sdf)
         return points_obj
 


### PR DESCRIPTION
0.24 sec -> 0.15 sec

In scikit-robot, transform operation is done around coordinates. So, we must use `copy_worldcoords()` when compositing  transformations. In `_transform_pts_sdf_to_obj` in `SignedDistanceFunction` class for example, calling `copy_worldcoords()` is unavoidable, in the current implementation. see: https://github.com/iory/scikit-robot/blob/ef5adf308bebf6aef82d69e7e836189e6eeb620c/skrobot/sdf/signed_distance_function.py#L128 

In my bench-marking of tinyfk-based , this `copy_worldcoords()` is the bottleneck 

```
from pyinstrument import Profiler
profiler = Profiler()
profiler.start()
ts = time.time()
av_seq = tinyfk_sqp_plan_trajectory(
    sscc, av_start, av_goal, joint_list, 10,
    safety_margin=1e-2, with_base=with_base)
print("solving time : {0} sec".format(time.time() - ts))
profiler.stop()
print(profiler.output_text(unicode=True, color=True, show_all=True))
```

Improved profile
```
Program: collision_free_trajectory.py

0.164 <module>  collision_free_trajectory.py:2
└─ 0.164 tinyfk_sqp_plan_trajectory  skrobot/planner/tinyfk_sqp_based.py:6
   └─ 0.164 _sqp_based_trajectory_optimization  skrobot/planner/sqp_based.py:99
      └─ 0.164 minimize  scipy/optimize/_minimize.py:42
         └─ 0.164 _minimize_slsqp  scipy/optimize/slsqp.py:215
            ├─ 0.110 [self]  
            ├─ 0.039 <listcomp>  scipy/optimize/slsqp.py:411
            │  └─ 0.039 fun_scipinized  skrobot/planner/utils.py:32
            │     └─ 0.039 fun_ineq  skrobot/planner/sqp_based.py:116
            │        └─ 0.039 collision_ineq_fun  skrobot/planner/tinyfk_sqp_based.py:38
            │           └─ 0.039 _compute_batch_sd_vals  skrobot/planner/tinyfk_collision_checker.py:48
            │              └─ 0.038 _compute_batch_sd_vals_internal  skrobot/planner/collision_checker.py:183
            │                 ├─ 0.027 <lambda>  collision_free_trajectory.py:56
            │                 │  └─ 0.027 __call__  skrobot/sdf/signed_distance_function.py:41
            │                 │     ├─ 0.020 _signed_distance  skrobot/sdf/signed_distance_function.py:185
            │                 │     │  ├─ 0.013 [self]  
            │                 │     │  └─ 0.007 sum  <__array_function__ internals>:2
            │                 │     │     └─ 0.007 sum  numpy/core/fromnumeric.py:2105
            │                 │     │        ├─ 0.003 _wrapreduction  numpy/core/fromnumeric.py:70
            │                 │     │        │  └─ 0.002 <dictcomp>  numpy/core/fromnumeric.py:71
            │                 │     │        └─ 0.003 [self]  
            │                 │     └─ 0.006 _transform_pts_obj_to_sdf  skrobot/sdf/signed_distance_function.py:98
            │                 │        ├─ 0.003 __call__  skrobot/coordinates/base.py:95
            │                 │        │  └─ 0.003 ndarray.dot  <built-in>:0
            │                 │        └─ 0.002 get_inverse  skrobot/coordinates/base.py:114
            │                 └─ 0.009 array  <built-in>:0
            ├─ 0.006 vstack  <__array_function__ internals>:2
            │  └─ 0.005 vstack  numpy/core/shape_base.py:223
            │     └─ 0.004 concatenate  <__array_function__ internals>:2
            │        └─ 0.004 implement_array_function  <built-in>:0
            ├─ 0.004 concatenate  <__array_function__ internals>:2
            │  └─ 0.004 implement_array_function  <built-in>:0
            └─ 0.002 append  <__array_function__ internals>:2
               └─ 0.002 append  numpy/lib/function_base.py:4616
```

before this change
```
Program: collision_free_trajectory.py

0.260 <module>  collision_free_trajectory.py:2
└─ 0.260 tinyfk_sqp_plan_trajectory  skrobot/planner/tinyfk_sqp_based.py:6
   └─ 0.260 _sqp_based_trajectory_optimization  skrobot/planner/sqp_based.py:99
      └─ 0.260 minimize  scipy/optimize/_minimize.py:42
         └─ 0.260 _minimize_slsqp  scipy/optimize/slsqp.py:215
            ├─ 0.123 [self]  
            ├─ 0.120 <listcomp>  scipy/optimize/slsqp.py:411
            │  └─ 0.118 fun_scipinized  skrobot/planner/utils.py:32
            │     └─ 0.118 fun_ineq  skrobot/planner/sqp_based.py:116
            │        └─ 0.118 collision_ineq_fun  skrobot/planner/tinyfk_sqp_based.py:38
            │           └─ 0.118 _compute_batch_sd_vals  skrobot/planner/tinyfk_collision_checker.py:48
            │              └─ 0.118 _compute_batch_sd_vals_internal  skrobot/planner/collision_checker.py:183
            │                 ├─ 0.110 <lambda>  collision_free_trajectory.py:56
            │                 │  └─ 0.109 __call__  skrobot/sdf/signed_distance_function.py:41
            │                 │     ├─ 0.080 _transform_pts_obj_to_sdf  skrobot/sdf/signed_distance_function.py:98
            │                 │     │  ├─ 0.040 copy_worldcoords  skrobot/coordinates/base.py:874
            │                 │     │  │  └─ 0.040 coords  skrobot/coordinates/base.py:865
            │                 │     │  │     └─ 0.040 copy_coords  skrobot/coordinates/base.py:860
            │                 │     │  │        └─ 0.037 __init__  skrobot/coordinates/base.py:99
            │                 │     │  │           └─ 0.037 rotation  skrobot/coordinates/base.py:153
            │                 │     │  │              ├─ 0.027 matrix2quaternion  skrobot/coordinates/math.py:582
            │                 │     │  │              │  ├─ 0.020 isclose  <__array_function__ internals>:2
            │                 │     │  │              │  │  └─ 0.020 isclose  numpy/core/numeric.py:2197
            │                 │     │  │              │  │     ├─ 0.015 within_tol  numpy/core/numeric.py:2274
            │                 │     │  │              │  │     │  ├─ 0.008 __enter__  numpy/core/_ufunc_config.py:433
            │                 │     │  │              │  │     │  │  ├─ 0.005 seterr  numpy/core/_ufunc_config.py:32
            │                 │     │  │              │  │     │  │  │  └─ 0.003 [self]  
            │                 │     │  │              │  │     │  │  └─ 0.003 [self]  
            │                 │     │  │              │  │     │  ├─ 0.004 [self]  
            │                 │     │  │              │  │     │  └─ 0.003 __exit__  numpy/core/_ufunc_config.py:438
            │                 │     │  │              │  │     │     └─ 0.003 seterr  numpy/core/_ufunc_config.py:32
            │                 │     │  │              │  │     └─ 0.003 all  <__array_function__ internals>:2
            │                 │     │  │              │  └─ 0.006 [self]  
            │                 │     │  │              └─ 0.008 _check_valid_rotation  skrobot/coordinates/math.py:88
            │                 │     │  │                 └─ 0.005 det  <__array_function__ internals>:2
            │                 │     │  │                    └─ 0.005 det  numpy/linalg/linalg.py:2105
            │                 │     │  │                       └─ 0.003 [self]  
            │                 │     │  └─ 0.038 transform  skrobot/coordinates/base.py:524
            │                 │     │     └─ 0.038 transform_coords  skrobot/coordinates/base.py:28
            │                 │     │        └─ 0.038 rotation  skrobot/coordinates/base.py:153
            │                 │     │           ├─ 0.018 _check_valid_rotation  skrobot/coordinates/math.py:88
            │                 │     │           │  ├─ 0.013 det  <__array_function__ internals>:2
            │                 │     │           │  │  └─ 0.012 det  numpy/linalg/linalg.py:2105
            │                 │     │           │  │     ├─ 0.004 [self]  
            │                 │     │           │  │     ├─ 0.003 float64.astype  <built-in>:0
            │                 │     │           │  │     └─ 0.003 _commonType  numpy/linalg/linalg.py:135
            │                 │     │           │  └─ 0.003 issubdtype  numpy/core/numerictypes.py:360
            │                 │     │           ├─ 0.016 quaternion2matrix  skrobot/coordinates/math.py:633
            │                 │     │           │  ├─ 0.008 allclose  <__array_function__ internals>:2
            │                 │     │           │  │  └─ 0.008 allclose  numpy/core/numeric.py:2121
            │                 │     │           │  │     └─ 0.006 all  <__array_function__ internals>:2
            │                 │     │           │  │        └─ 0.006 all  numpy/core/fromnumeric.py:2337
            │                 │     │           │  │           └─ 0.005 _wrapreduction  numpy/core/fromnumeric.py:70
            │                 │     │           │  │              └─ 0.003 [self]  
            │                 │     │           │  └─ 0.007 [self]  
            │                 │     │           └─ 0.003 [self]  
            │                 │     └─ 0.028 _signed_distance  skrobot/sdf/signed_distance_function.py:182
            │                 │        ├─ 0.015 [self]  
            │                 │        ├─ 0.008 amax  <__array_function__ internals>:2
            │                 │        │  └─ 0.007 amax  numpy/core/fromnumeric.py:2589
            │                 │        │     └─ 0.006 _wrapreduction  numpy/core/fromnumeric.py:70
            │                 │        │        └─ 0.006 ufunc.reduce  <built-in>:0
            │                 │        └─ 0.005 sum  <__array_function__ internals>:2
            │                 │           └─ 0.004 sum  numpy/core/fromnumeric.py:2105
            │                 │              └─ 0.003 _wrapreduction  numpy/core/fromnumeric.py:70
            │                 │                 └─ 0.003 ufunc.reduce  <built-in>:0
            │                 ├─ 0.003 [self]  
            │                 └─ 0.003 block_diag  scipy/linalg/special_matrices.py:473
            ├─ 0.005 vstack  <__array_function__ internals>:2
            │  └─ 0.005 vstack  numpy/core/shape_base.py:223
            │     └─ 0.004 concatenate  <__array_function__ internals>:2
            │        └─ 0.004 implement_array_function  <built-in>:0
            ├─ 0.004 function_wrapper  scipy/optimize/optimize.py:298
            │  └─ 0.003 fun_scipinized  skrobot/planner/utils.py:32
            │     └─ 0.003 fun_objective  skrobot/planner/sqp_based.py:111
            │        └─ 0.003 ndarray.dot  <built-in>:0
            └─ 0.003 concatenate  <__array_function__ internals>:2
               └─ 0.003 implement_array_function  <built-in>:0

```

```
from pyinstrument import Profiler
profiler = Profiler()
profiler.start()
ts = time.time()
av_seq = tinyfk_sqp_plan_trajectory(
    sscc, av_start, av_goal, joint_list, 10,
    safety_margin=1e-2, with_base=with_base)
print("solving time : {0} sec".format(time.time() - ts))
profiler.stop()
print(profiler.output_text(unicode=True, color=True, show_all=True))

```